### PR TITLE
Add OpenTelemetry deployment yaml

### DIFF
--- a/OpenTelemetry/README.md
+++ b/OpenTelemetry/README.md
@@ -1,0 +1,3 @@
+### Reference
+fork from https://opentelemetry.io/docs/collector/getting-started/#kubernetes
+origin yaml: https://raw.githubusercontent.com/open-telemetry/opentelemetry-collector/main/examples/k8s/otel-config.yaml

--- a/OpenTelemetry/open-telemetry.yaml
+++ b/OpenTelemetry/open-telemetry.yaml
@@ -1,0 +1,117 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-agent-conf
+  labels:
+    app: opentelemetry
+    component: otel-agent-conf
+data:
+  otel-agent-config: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+          http:
+    exporters:
+      otlphttp:
+        traces_endpoint: "http://${HOST_IP}:38086/api/v1/otel/trace"
+        tls:
+          insecure: true
+        retry_on_failure:
+          enabled: true
+    processors:
+      batch:
+      memory_limiter:
+        # 80% of maximum memory up to 2G
+        limit_mib: 400
+        # 25% of limit up to 2G
+        spike_limit_mib: 100
+        check_interval: 5s
+      k8sattributes:
+      resource:
+        attributes:
+        - key: app.host.ip
+          from_attribute: k8s.pod.ip
+          action: insert
+    extensions:
+      zpages: {}
+      memory_ballast:
+        # Memory Ballast size should be max 1/3 to 1/2 of memory.
+        size_mib: 165
+    service:
+      extensions: [zpages, memory_ballast]
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: k8sattributes, resource, memory_limiter, batch]
+          exporters: [otlphttp]
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: otel-agent
+  labels:
+    app: opentelemetry
+    component: otel-agent
+spec:
+  selector:
+    matchLabels:
+      app: opentelemetry
+      component: otel-agent
+  template:
+    metadata:
+      labels:
+        app: opentelemetry
+        component: otel-agent
+    spec:
+      containers:
+      - command:
+          - "/otelcol"
+          - "--config=/conf/otel-agent-config.yaml"
+        image: otel/opentelemetry-collector-contrib:0.55.0
+        name: otel-agent
+        resources:
+          limits:
+            cpu: 1
+            memory: 2Gi
+          requests:
+            cpu: 200m
+            memory: 400Mi
+        ports:
+        - containerPort: 55679 # ZPages endpoint.
+        - containerPort: 4317 # Default OpenTelemetry receiver port.
+        - containerPort: 4318
+        - containerPort: 8888  # Metrics.
+        volumeMounts:
+        - name: otel-agent-config-vol
+          mountPath: /conf
+      volumes:
+        - configMap:
+            name: otel-agent-conf
+            items:
+              - key: otel-agent-config
+                path: otel-agent-config.yaml
+          name: otel-agent-config-vol
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-agent
+  labels:
+    app: opentelemetry
+    component: otel-agent
+spec:
+  ports:
+  - name: otlp-grpc # Default endpoint for OpenTelemetry gRPC receiver.
+    port: 4317
+    protocol: TCP
+    targetPort: 4317
+  - name: otlp-http # Default endpoint for OpenTelemetry HTTP receiver.
+    port: 4318
+    protocol: TCP
+    targetPort: 4318
+  - name: metrics # Default endpoint for querying metrics.
+    port: 8888
+  selector:
+    component: otel-agent

--- a/OpenTelemetry/open-telemetry.yaml
+++ b/OpenTelemetry/open-telemetry.yaml
@@ -83,6 +83,12 @@ spec:
         - containerPort: 4317 # Default OpenTelemetry receiver port.
         - containerPort: 4318
         - containerPort: 8888  # Metrics.
+        env:
+          - name: HOST_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.hostIP
         volumeMounts:
         - name: otel-agent-config-vol
           mountPath: /conf


### PR DESCRIPTION
Add OpenTelemetry deploy yaml for kubernetes .
Original source: https://raw.githubusercontent.com/open-telemetry/opentelemetry-collector/main/examples/k8s/otel-config.yaml